### PR TITLE
Add python3.7 to travis and tox.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ dist: trusty
 language: python
 jobs:
   include:
+    - python: 3.7
+      dist: xenial
+      sudo: required
     - python: 3.6
     - python: 3.5
 notifications:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36
+envlist = py35, py36, py37
 
 [testenv]
 setenv =


### PR DESCRIPTION
Note current tensorflow version 1.8.1 doesn't support python3.7.
Need to upgrade tensorflow to at least 1.13